### PR TITLE
Bump paint-rails to use paint 0.6.7

### DIFF
--- a/lib/paint-rails/version.rb
+++ b/lib/paint-rails/version.rb
@@ -1,5 +1,5 @@
 module Paint
   module Rails
-    VERSION = "0.6.1"
+    VERSION = "0.6.7"
   end
 end

--- a/vendor/assets/stylesheets/components/_button.scss
+++ b/vendor/assets/stylesheets/components/_button.scss
@@ -42,14 +42,26 @@ $include-html-paint-button: true !default;
 
 %button-primary {
   @include button(
-    $bg: $button-primary-background-color,
+    $bg: $white,
     $padding: $column-gutter / 2,
     $radius: $global-radius
   );
 
+  border: 1px solid $button-primary-background-color;
+  color: $button-primary-background-color;
   font-size: $small-font-size;
   font-weight: $font-weight-bold;
   text-transform: uppercase;
+
+  &:focus {
+    background-color: $white;
+    color: $button-primary-background-color;
+  }
+
+  &:hover {
+    background-color: $button-primary-background-color;
+    color: $white;
+  }
 }
 
 @include exports("paint-button") {

--- a/vendor/assets/stylesheets/components/_typography.scss
+++ b/vendor/assets/stylesheets/components/_typography.scss
@@ -1,6 +1,4 @@
 $typography-header-tags: h1, h2, h3, h4, h5, h6, blockquote !default;
-$typography-condensed-header-tags: h1, h2, blockquote !default;
-$typography-condensed-letter-spacing: -1px !default;
 
 $include-html-paint-typography: true !default;
 
@@ -18,19 +16,8 @@ $include-html-paint-typography: true !default;
   }
 }
 
-@mixin typography-condensed-header($tags: $typography-condensed-header-tags) {
-  @for $i from 1 through length($tags) {
-    $tag: nth($tags, $i);
-
-    #{$tag} {
-      letter-spacing: $typography-condensed-letter-spacing;
-    }
-  }
-}
-
 @include exports("paint-typography") {
   @if $include-html-paint-typography {
     @include typography-font-smoothing;
-    @include typography-condensed-header;
   }
 }

--- a/vendor/assets/stylesheets/paint.scss
+++ b/vendor/assets/stylesheets/paint.scss
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,600,300");
-
 @import "bower_components/foundation/scss/foundation/functions";
 
 @import "globals/settings";


### PR DESCRIPTION
## What's up?

This updates the rails gem to use paint 0.6.7

@deioo does it this reflect the recent changes made to paint? I basically just a rake task to pull in changes, good to have your :eyes: on this.

@katherinlaine can you review this?